### PR TITLE
Update the quickstart text to speak about framework

### DIFF
--- a/hugo/content/introitem/quickstart.md
+++ b/hugo/content/introitem/quickstart.md
@@ -1,9 +1,9 @@
 ---
-title: Quickstart
-instruction: Get up and running with the quickstart guide
+title: Get started
+instruction: Get up and running with the Dolittle framework
 icon: icon-wrench
 ctaButton:
     text: Get Started
-    url: 'https://dolittle.io/getting-started/quickstart/'
+    url: 'https://dolittle.io/getting-started/'
 weight: 2
 ---


### PR DESCRIPTION
Also updated the link to take you to the getting started page instead the setup part of the tutorial.

I couldn't test this locally but should be all fine.

https://5e5797c8e9c7d6000a600823--dolittle-com.netlify.com/